### PR TITLE
fuzzers: activate service account at startup

### DIFF
--- a/fuzzers/main.py
+++ b/fuzzers/main.py
@@ -36,17 +36,6 @@ SYNC_LOG_UPLOAD_INTERVAL = datetime.timedelta(3600)
 #AUTO_REFRESH_INTERVAL = datetime.timedelta(seconds=300)
 #SYNC_LOG_UPLOAD_INTERVAL = datetime.timedelta(seconds=30)
 
-
-def connect_to_gcs() -> gcs.Client:
-    """Setup the environment to have gsutils work, and return a connection to GCS"""
-    credentials = config.CONFIG_DIR / 'credentials.json'
-    subprocess.check_call((
-        'gcloud', 'auth', 'activate-service-account', '--key-file', credentials
-    ))
-    return gcs.Client.from_service_account_json(str(credentials))
-    #return gcs.Client(project = 'near-nayduck')
-
-
 NUM_FUZZERS = typing.cast(int, os.cpu_count())
 #NUM_FUZZERS = 1
 
@@ -58,6 +47,7 @@ LOGS_DIR = WORKDIR / 'fuzz-logs'
 CORPUS_DIR = WORKDIR / 'fuzz-corpus'
 
 ZULIPRC = config.CONFIG_DIR / 'zuliprc'
+GCS_CREDENTIALS_FILE = config.CONFIG_DIR / 'credentials.json'
 GCS_BUCKET = 'fuzzer'
 
 FUZZ_BUILD_TIME = prometheus_client.Counter('fuzz_build_seconds',
@@ -94,6 +84,14 @@ ConfigType = TypedDict('ConfigType', {
 
 # Branch name -> list of reported artifacts
 REPORTED_ARTIFACTS: typing.DefaultDict[str, list[str]] = defaultdict(list)
+
+
+def connect_to_gcs() -> gcs.Client:
+    """Setup the environment to have gsutils work, and return a connection to GCS"""
+    subprocess.check_call(('gcloud', 'auth', 'activate-service-account',
+                           '--key-file', GCS_CREDENTIALS_FILE))
+    return gcs.Client.from_service_account_json(str(GCS_CREDENTIALS_FILE))
+    #return gcs.Client(project = 'near-nayduck')
 
 
 class Repository:

--- a/fuzzers/main.py
+++ b/fuzzers/main.py
@@ -39,14 +39,11 @@ SYNC_LOG_UPLOAD_INTERVAL = datetime.timedelta(3600)
 
 def connect_to_gcs() -> gcs.Client:
     """Setup the environment to have gsutils work, and return a connection to GCS"""
-    #subprocess.run(
-    #    [
-    #        'gcloud', 'auth', 'activate-service-account', '--key-file',
-    #        GCS_CREDENTIALS_FILE
-    #    ],
-    #    check=True,
-    #)
-    return gcs.Client.from_service_account_json(str(GCS_CREDENTIALS_FILE))
+    credentials = config.CONFIG_DIR / 'credentials.json'
+    subprocess.check_call((
+        'gcloud', 'auth', 'activate-service-account', '--key-file', credentials
+    ))
+    return gcs.Client.from_service_account_json(str(credentials))
     #return gcs.Client(project = 'near-nayduck')
 
 
@@ -61,7 +58,6 @@ LOGS_DIR = WORKDIR / 'fuzz-logs'
 CORPUS_DIR = WORKDIR / 'fuzz-corpus'
 
 ZULIPRC = config.CONFIG_DIR / 'zuliprc'
-GCS_CREDENTIALS_FILE = config.CONFIG_DIR / 'credentials.json'
 GCS_BUCKET = 'fuzzer'
 
 FUZZ_BUILD_TIME = prometheus_client.Counter('fuzz_build_seconds',


### PR DESCRIPTION
I wrongly believed that gsutil would use machine’s service account when
authenticating with the cloud.  However, that does not happen.  The gcloud
activate-service-account call is required after all so uncomment it.  Note
that the command needs to be called only once but to keep things simpler
we’re calling it each time fuzzer starts.  This should not have negative
effects.