### PR TITLE
Show that additional binaries are built with test_features in the web ui

### DIFF
--- a/frontend/src/a_test.js
+++ b/frontend/src/a_test.js
@@ -19,8 +19,8 @@ export function parseTestName(test) {
         ? ' ' + featuresArray.join(' ') + ',test_features'
         : ' --features test_features';
     const additionalBinariesFeatures = featuresArray.includes('nightly')
-        ? '--features nightly '
-        : '';
+        ? '--features test_features,nightly '
+        : '--features test_features ';
     let release = '';
     let i = 1;
     for (; /^--/.test(spec[i] || ''); ++i) {


### PR DESCRIPTION
Since https://github.com/Near-One/nayduck/pull/56 all tools/additional binaries are built with the `test_features` feature, but this wasn't shown in the web ui. Web UI still shows the old build command without test features. This can lead to confusion - I copied the command to run a failing test from web ui, but it didn't work because it didn't contain the test_features feature.

Ref: https://github.com/near/nearcore/issues/12305